### PR TITLE
Add Drupal 8 monolog configuration example

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ This list is maintained by @xtfer. Pull Requests welcome.
 
 * [Modifying distribution make files for Platform.sh](https://www.nickvahalik.com/blog-entry/modifying-distribution-makefiles-within-your-own-project-makefile-platformsh) 
 * Platform.sh [Drupal 8 Development Workflow](https://github.com/JohnatasJMO/platformsh-development-workflow) by @JohnatasJMO
-* [Log using Monolog](https://gist.github.com/janstoeckler/7f251bf10fedbfb7f752b61ee5d2ef5e) to keep log files out of the database (and/or use whatever processors & handlers you want)
+* Syslogging is not supported on Platform.sh, instead, you can [Log using Monolog](https://gist.github.com/janstoeckler/7f251bf10fedbfb7f752b61ee5d2ef5e) to keep log files out of the database (and/or use whatever processors & handlers you want)
 
 ### Magento
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ This list is maintained by @xtfer. Pull Requests welcome.
 
 * [Modifying distribution make files for Platform.sh](https://www.nickvahalik.com/blog-entry/modifying-distribution-makefiles-within-your-own-project-makefile-platformsh) 
 * Platform.sh [Drupal 8 Development Workflow](https://github.com/JohnatasJMO/platformsh-development-workflow) by @JohnatasJMO
+* [Log using Monolog](https://gist.github.com/janstoeckler/7f251bf10fedbfb7f752b61ee5d2ef5e) to keep log files out of the database (and/or use whatever processors & handlers you want)
 
 ### Magento
 


### PR DESCRIPTION
As discussed in platform.sh's slack, a minimal guide on how to configure monolog logging in Drupal 8 - works on platform.sh & may be useful.